### PR TITLE
Failed build should stop deploy

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -22,6 +22,15 @@ jobs:
       -   name: gradle jsBrowserProductionLibraryDistribution
           working-directory: webtool/gradle/common
           run: gradle jsBrowserProductionLibraryDistribution
+      -   uses: actions/setup-node@v4
+          with:
+              node-version: 22
+              cache: npm
+              cache-dependency-path: ./webtool/frontend/package-lock.json
+      -   run: npm install
+          working-directory: ./webtool/frontend
+      -   run: npm run build
+          working-directory: ./webtool/frontend
       -   name: Build And Deploy
           id: builddeploy
           uses: Azure/static-web-apps-deploy@v1
@@ -34,9 +43,10 @@ jobs:
             action: "upload"
             ###### Repository/Build Configurations - These values can be configured to match your app requirements. ######
             # For more information regarding Static Web App workflow configurations, please visit: https://aka.ms/swaworkflowconfig
-            app_location: "/webtool/frontend" # App source code path
+            # We build in previous steps, because a build failure at this step doesn't block the deploy.
+            skip_app_build: true
+            app_location: "/webtool/frontend/dist"
             api_location: "" # Api source code path - optional
-            output_location: "dist" # Built app content directory - optional
             ###### End of Repository/Build Configurations ######
 
   deploy-backend:


### PR DESCRIPTION
The Azure Static Web App GitHub action plugin doesn't abort the deploy when npm build fails. This change removes this responsibility from the plugin to its own step.

Closes #93